### PR TITLE
cbuild_path via cbuild_temp

### DIFF
--- a/tests/FS_path_basename.c
+++ b/tests/FS_path_basename.c
@@ -1,18 +1,15 @@
 int main(void) {
 	const char* p1 = "some/dir/file.txt";
 	const char* n1 = cbuild_path_base(p1);
-	TEST_ASSERT_STREQ(n1, "some/dir/", "Wrong basename extracted from \"%s\"",
+	TEST_ASSERT_STREQ(n1, "some/dir/", "Wrong basename extracted from \"%s\""
 		TEST_EXPECT_MSG(s), p1, "some/dir/", n1);
 	const char* p2 = "some/dir/another_dir/";
 	const char* n2 = cbuild_path_base(p2);
-	TEST_ASSERT_STREQ(n2, "some/dir/", "Wrong basename extracted from \"%s\"",
+	TEST_ASSERT_STREQ(n2, "some/dir/", "Wrong basename extracted from \"%s\""
 		TEST_EXPECT_MSG(s), p2, "some/dir/", n2);
 	const char* p3 = "a.c";
 	const char* n3 = cbuild_path_base(p3);
-	TEST_ASSERT_STREQ(n3, "", "Wrong basename extracted from \"%s\"",
+	TEST_ASSERT_STREQ(n3, "", "Wrong basename extracted from \"%s\""
 		TEST_EXPECT_MSG(s), p3, "", n3);
-	free((void*)n1);
-	free((void*)n2);
-	free((void*)n3);
 	return 0;
 }

--- a/tests/FS_path_ext.c
+++ b/tests/FS_path_ext.c
@@ -15,9 +15,9 @@ int main(void) {
 	const char* e4 = cbuild_path_ext(p4);
 	TEST_ASSERT_STREQ(e4, "", "Wrong extension extracted from \"%s\""
 		TEST_EXPECT_MSG(s), p4, "", e4);
-	free((void*)e1);
-	free((void*)e2);
-	free((void*)e3);
-	free((void*)e4);
+	const char* p5 = "file.tar.gz";
+	const char* e5 = cbuild_path_ext(p4, .dot = 2);
+	TEST_ASSERT_STREQ(e5, "", "Wrong extension extracted from \"%s\""
+		TEST_EXPECT_MSG(s), p5, "tar.gz", e5);
 	return 0;
 }

--- a/tests/FS_path_filename.c
+++ b/tests/FS_path_filename.c
@@ -11,8 +11,5 @@ int main(void) {
 	const char* n3 = cbuild_path_name(p3);
 	TEST_ASSERT_STREQ(n3, "a.c", "Wrong filename extracted from \"%s\""
 		TEST_EXPECT_MSG(s), p3, "a.c", n3);
-	free((void*)n1);
-	free((void*)n2);
-	free((void*)n3);
 	return 0;
 }

--- a/tests/FS_path_normalize.c
+++ b/tests/FS_path_normalize.c
@@ -6,56 +6,49 @@ int main(void) {
 	char* o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("/usr/bin", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "/usr/bin", o);
-	free(o);
 	i = "/usr//bin///env";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("/usr/bin/env", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "/usr/bin/env", o);
-	free(o);
 	i = "./src/././main.c";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("src/main.c", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "src/main.c", o);
-	free(o);
 	i = "src/../include/header.h";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("include/header.h", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "include/header.h", o);
-	free(o);
 	i = "../../etc/config";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("../../etc/config", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "../../etc/config", o);
-	free(o);
 	i = "/home/user/.././docs//file.txt";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("/home/docs/file.txt", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "/home/docs/file.txt", o);
-	free(o);
 	i = "///";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("/", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "/", o);
-	free(o);
 	i = "./././";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ(".", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, ".", o);
-	free(o);
 	i = "../a/./b/../../c/";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("../c", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "../c", o);
-	free(o);
 	i = "";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ(".", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, ".", o);
-	free(o);
 	i = "..";
 	o = cbuild_path_normalize(i);
 	TEST_ASSERT_STREQ("..", o, "Wrong path after normalization of \"%s\""
 		TEST_EXPECT_MSG(s), i, "..", o);
-	free(o);
+	i = "C:/abc////d";
+	o = cbuild_path_normalize(i);
+	TEST_ASSERT_STREQ("C:/abc/d", o, "Wrong path after normalization of \"%s\""
+		TEST_EXPECT_MSG(s), i, "C:/abc/d", o);
 	return 0;
 }

--- a/wikimk.c
+++ b/wikimk.c
@@ -163,7 +163,7 @@ bool gentoc_subdir_recursively(const char* name, cbuild_sb_t* out) {
 				cbuild_sb_t buffer = {0};
 				cbuild_file_read(filepath.data, &buffer);
 				cbuild_sv_t buffer_sv = cbuild_sb_to_sv(buffer);
-				cbuild_sv_t	name = cbuild_sv_chop_by_delim(&buffer_sv, '\n');
+				cbuild_sv_t	name_sv = cbuild_sv_chop_by_delim(&buffer_sv, '\n');
 				cbuild_sv_t url = cbuild_sv_chop_by_delim(&buffer_sv, '\n');
 				cbuild_sb_appendf(out, "<li><a href =\"");
 				if(cbuild_sv_prefix(url, cbuild_sv_from_cstr("http"))) {
@@ -173,7 +173,7 @@ bool gentoc_subdir_recursively(const char* name, cbuild_sb_t* out) {
 					cbuild_sb_appendf(out, "%s"CBuildSVFmt, base, CBuildSVArg(url));
 					free((void*)base);
 				}
-				cbuild_sb_appendf(out, "\">"CBuildSVFmt"</a></li>\n", CBuildSVArg(name));
+				cbuild_sb_appendf(out, "\">"CBuildSVFmt"</a></li>\n", CBuildSVArg(name_sv));
 			}
 		} break;
 		case CBUILD_FTYPE_DIRECTORY: {

--- a/wikimk.c
+++ b/wikimk.c
@@ -169,9 +169,10 @@ bool gentoc_subdir_recursively(const char* name, cbuild_sb_t* out) {
 				if(cbuild_sv_prefix(url, cbuild_sv_from_cstr("http"))) {
 					cbuild_sb_append_sv(out, url);
 				} else {
-					const char *base = cbuild_path_base(filename.data);
+					size_t checkpoint = cbuild_temp_checkpoint();
+					char *base = cbuild_path_base(filename.data);
 					cbuild_sb_appendf(out, "%s"CBuildSVFmt, base, CBuildSVArg(url));
-					free((void*)base);
+					cbuild_temp_reset(checkpoint);
 				}
 				cbuild_sb_appendf(out, "\">"CBuildSVFmt"</a></li>\n", CBuildSVArg(name_sv));
 			}
@@ -416,9 +417,10 @@ void http_server_build_mimecache(void) {
 	// TODO: More mimetypes ?
 }
 char*	http_server_mime(const char* filepath) {
+	size_t checkpoint = cbuild_temp_checkpoint();
 	char* ext = cbuild_path_ext(filepath);
 	char** elem = cbuild_map_get(&http_server_mimecache, ext);
-	free(ext);
+	cbuild_temp_reset(checkpoint);
 	if(elem == NULL) {
 		return "application/octet-stream";
 	} else {


### PR DESCRIPTION
- **Fixed warning in wikimk**
- **Improved cbuild_path* API**
  * Now all function use cbuild\_temp allocator and not malloc.
  * cbuild\_path\_ext not take additional optional parameter .dot to support
  * chopping extensions starting from n-th dot from the end.
  * cbuild\_path\_normalize can normalize windows paths with drive letter.
  * Updated tests, cbuild.h and wikimk.c for a new code.

Closes #1
